### PR TITLE
Add team bind-card links and copyable token summaries

### DIFF
--- a/frontend/src/views/AccountsView.vue
+++ b/frontend/src/views/AccountsView.vue
@@ -255,16 +255,60 @@
           <el-divider content-position="left">Token 摘要</el-divider>
           <div class="token-grid">
             <div class="token-card">
-              <span class="detail-item__label">Access Token</span>
-              <code>{{ selectedTokens.access_token || '-' }}</code>
+              <div class="token-card__header">
+                <span class="detail-item__label">Access Token</span>
+                <el-button
+                  link
+                  type="primary"
+                  :disabled="!selectedTokens.access_token"
+                  @click="copyValue(selectedTokens.access_token, 'Access Token')"
+                >
+                  复制
+                </el-button>
+              </div>
+              <code>{{ selectedTokens.access_token_summary || '-' }}</code>
             </div>
             <div class="token-card">
-              <span class="detail-item__label">Refresh Token</span>
-              <code>{{ selectedTokens.refresh_token || '-' }}</code>
+              <div class="token-card__header">
+                <span class="detail-item__label">Refresh Token</span>
+                <el-button
+                  link
+                  type="primary"
+                  :disabled="!selectedTokens.refresh_token"
+                  @click="copyValue(selectedTokens.refresh_token, 'Refresh Token')"
+                >
+                  复制
+                </el-button>
+              </div>
+              <code>{{ selectedTokens.refresh_token_summary || '-' }}</code>
             </div>
             <div class="token-card">
-              <span class="detail-item__label">ID Token</span>
-              <code>{{ selectedTokens.id_token || '-' }}</code>
+              <div class="token-card__header">
+                <span class="detail-item__label">ID Token</span>
+                <el-button
+                  link
+                  type="primary"
+                  :disabled="!selectedTokens.id_token"
+                  @click="copyValue(selectedTokens.id_token, 'ID Token')"
+                >
+                  复制
+                </el-button>
+              </div>
+              <code>{{ selectedTokens.id_token_summary || '-' }}</code>
+            </div>
+            <div class="token-card">
+              <div class="token-card__header">
+                <span class="detail-item__label">绑卡链接</span>
+                <el-button
+                  link
+                  type="primary"
+                  :disabled="!selectedTokens.bind_card_url"
+                  @click="copyValue(selectedTokens.bind_card_url, '绑卡链接')"
+                >
+                  复制
+                </el-button>
+              </div>
+              <code>{{ selectedTokens.bind_card_url_summary || '-' }}</code>
             </div>
           </div>
         </template>
@@ -304,8 +348,13 @@ type AccountStats = {
 
 type AccountTokens = {
   access_token?: string | null
+  access_token_summary?: string | null
   refresh_token?: string | null
+  refresh_token_summary?: string | null
   id_token?: string | null
+  id_token_summary?: string | null
+  bind_card_url?: string | null
+  bind_card_url_summary?: string | null
   has_tokens?: boolean
 }
 
@@ -499,6 +548,38 @@ async function runBatchAction(action: BatchAction) {
   } finally {
     batchAction.value = ''
   }
+}
+
+async function copyValue(value: string | null | undefined, label: string) {
+  const trimmed = value?.trim()
+  if (!trimmed) {
+    ElMessage.warning(`${label} 不可复制`)
+    return
+  }
+
+  try {
+    await writeClipboard(trimmed)
+    ElMessage.success(`${label} 已复制`)
+  } catch {
+    ElMessage.error(`${label} 复制失败`)
+  }
+}
+
+async function writeClipboard(value: string) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(value)
+    return
+  }
+
+  const textarea = document.createElement('textarea')
+  textarea.value = value
+  textarea.setAttribute('readonly', 'true')
+  textarea.style.position = 'fixed'
+  textarea.style.opacity = '0'
+  document.body.appendChild(textarea)
+  textarea.select()
+  document.execCommand('copy')
+  document.body.removeChild(textarea)
 }
 
 function applyFilters() {
@@ -729,6 +810,13 @@ onMounted(() => {
   padding: 14px;
   border-radius: 14px;
   background: #f8fafc;
+}
+
+.token-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .token-card code {

--- a/frontend/src/views/AccountsView.vue.js
+++ b/frontend/src/views/AccountsView.vue.js
@@ -171,6 +171,35 @@ async function runBatchAction(action) {
         batchAction.value = '';
     }
 }
+async function copyValue(value, label) {
+    const trimmed = value?.trim();
+    if (!trimmed) {
+        ElMessage.warning(`${label} 不可复制`);
+        return;
+    }
+    try {
+        await writeClipboard(trimmed);
+        ElMessage.success(`${label} 已复制`);
+    }
+    catch {
+        ElMessage.error(`${label} 复制失败`);
+    }
+}
+async function writeClipboard(value) {
+    if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(value);
+        return;
+    }
+    const textarea = document.createElement('textarea');
+    textarea.value = value;
+    textarea.setAttribute('readonly', 'true');
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+}
 function applyFilters() {
     filters.page = 1;
     refreshAll();
@@ -1306,35 +1335,181 @@ if (__VLS_ctx.selectedAccount) {
         ...{ class: "token-card" },
     });
     /** @type {__VLS_StyleScopedClasses['token-card']} */ ;
+    __VLS_asFunctionalElement1(__VLS_intrinsics.div, __VLS_intrinsics.div)({
+        ...{ class: "token-card__header" },
+    });
+    /** @type {__VLS_StyleScopedClasses['token-card__header']} */ ;
     __VLS_asFunctionalElement1(__VLS_intrinsics.span, __VLS_intrinsics.span)({
         ...{ class: "detail-item__label" },
     });
     /** @type {__VLS_StyleScopedClasses['detail-item__label']} */ ;
+    let __VLS_262;
+    /** @ts-ignore @type {typeof __VLS_components.elButton | typeof __VLS_components.ElButton | typeof __VLS_components.elButton | typeof __VLS_components.ElButton} */
+    elButton;
+    // @ts-ignore
+    const __VLS_263 = __VLS_asFunctionalComponent1(__VLS_262, new __VLS_262({
+        ...{ 'onClick': {} },
+        link: true,
+        type: "primary",
+        disabled: (!__VLS_ctx.selectedTokens.access_token),
+    }));
+    const __VLS_264 = __VLS_263({
+        ...{ 'onClick': {} },
+        link: true,
+        type: "primary",
+        disabled: (!__VLS_ctx.selectedTokens.access_token),
+    }, ...__VLS_functionalComponentArgsRest(__VLS_263));
+    let __VLS_267;
+    const __VLS_268 = ({ click: {} },
+        { onClick: (...[$event]) => {
+                if (!(__VLS_ctx.selectedAccount))
+                    return;
+                __VLS_ctx.copyValue(__VLS_ctx.selectedTokens.access_token, 'Access Token');
+                // @ts-ignore
+                [selectedTokens, selectedTokens, copyValue,];
+            } });
+    const { default: __VLS_269 } = __VLS_265.slots;
+    // @ts-ignore
+    [];
+    var __VLS_265;
+    var __VLS_266;
     __VLS_asFunctionalElement1(__VLS_intrinsics.code, __VLS_intrinsics.code)({});
-    (__VLS_ctx.selectedTokens.access_token || '-');
+    (__VLS_ctx.selectedTokens.access_token_summary || '-');
     __VLS_asFunctionalElement1(__VLS_intrinsics.div, __VLS_intrinsics.div)({
         ...{ class: "token-card" },
     });
     /** @type {__VLS_StyleScopedClasses['token-card']} */ ;
+    __VLS_asFunctionalElement1(__VLS_intrinsics.div, __VLS_intrinsics.div)({
+        ...{ class: "token-card__header" },
+    });
+    /** @type {__VLS_StyleScopedClasses['token-card__header']} */ ;
     __VLS_asFunctionalElement1(__VLS_intrinsics.span, __VLS_intrinsics.span)({
         ...{ class: "detail-item__label" },
     });
     /** @type {__VLS_StyleScopedClasses['detail-item__label']} */ ;
+    let __VLS_270;
+    /** @ts-ignore @type {typeof __VLS_components.elButton | typeof __VLS_components.ElButton | typeof __VLS_components.elButton | typeof __VLS_components.ElButton} */
+    elButton;
+    // @ts-ignore
+    const __VLS_271 = __VLS_asFunctionalComponent1(__VLS_270, new __VLS_270({
+        ...{ 'onClick': {} },
+        link: true,
+        type: "primary",
+        disabled: (!__VLS_ctx.selectedTokens.refresh_token),
+    }));
+    const __VLS_272 = __VLS_271({
+        ...{ 'onClick': {} },
+        link: true,
+        type: "primary",
+        disabled: (!__VLS_ctx.selectedTokens.refresh_token),
+    }, ...__VLS_functionalComponentArgsRest(__VLS_271));
+    let __VLS_275;
+    const __VLS_276 = ({ click: {} },
+        { onClick: (...[$event]) => {
+                if (!(__VLS_ctx.selectedAccount))
+                    return;
+                __VLS_ctx.copyValue(__VLS_ctx.selectedTokens.refresh_token, 'Refresh Token');
+                // @ts-ignore
+                [selectedTokens, selectedTokens, selectedTokens, copyValue,];
+            } });
+    const { default: __VLS_277 } = __VLS_273.slots;
+    // @ts-ignore
+    [];
+    var __VLS_273;
+    var __VLS_274;
     __VLS_asFunctionalElement1(__VLS_intrinsics.code, __VLS_intrinsics.code)({});
-    (__VLS_ctx.selectedTokens.refresh_token || '-');
+    (__VLS_ctx.selectedTokens.refresh_token_summary || '-');
     __VLS_asFunctionalElement1(__VLS_intrinsics.div, __VLS_intrinsics.div)({
         ...{ class: "token-card" },
     });
     /** @type {__VLS_StyleScopedClasses['token-card']} */ ;
+    __VLS_asFunctionalElement1(__VLS_intrinsics.div, __VLS_intrinsics.div)({
+        ...{ class: "token-card__header" },
+    });
+    /** @type {__VLS_StyleScopedClasses['token-card__header']} */ ;
     __VLS_asFunctionalElement1(__VLS_intrinsics.span, __VLS_intrinsics.span)({
         ...{ class: "detail-item__label" },
     });
     /** @type {__VLS_StyleScopedClasses['detail-item__label']} */ ;
+    let __VLS_278;
+    /** @ts-ignore @type {typeof __VLS_components.elButton | typeof __VLS_components.ElButton | typeof __VLS_components.elButton | typeof __VLS_components.ElButton} */
+    elButton;
+    // @ts-ignore
+    const __VLS_279 = __VLS_asFunctionalComponent1(__VLS_278, new __VLS_278({
+        ...{ 'onClick': {} },
+        link: true,
+        type: "primary",
+        disabled: (!__VLS_ctx.selectedTokens.id_token),
+    }));
+    const __VLS_280 = __VLS_279({
+        ...{ 'onClick': {} },
+        link: true,
+        type: "primary",
+        disabled: (!__VLS_ctx.selectedTokens.id_token),
+    }, ...__VLS_functionalComponentArgsRest(__VLS_279));
+    let __VLS_283;
+    const __VLS_284 = ({ click: {} },
+        { onClick: (...[$event]) => {
+                if (!(__VLS_ctx.selectedAccount))
+                    return;
+                __VLS_ctx.copyValue(__VLS_ctx.selectedTokens.id_token, 'ID Token');
+                // @ts-ignore
+                [selectedTokens, selectedTokens, selectedTokens, copyValue,];
+            } });
+    const { default: __VLS_285 } = __VLS_281.slots;
+    // @ts-ignore
+    [];
+    var __VLS_281;
+    var __VLS_282;
     __VLS_asFunctionalElement1(__VLS_intrinsics.code, __VLS_intrinsics.code)({});
-    (__VLS_ctx.selectedTokens.id_token || '-');
+    (__VLS_ctx.selectedTokens.id_token_summary || '-');
+    __VLS_asFunctionalElement1(__VLS_intrinsics.div, __VLS_intrinsics.div)({
+        ...{ class: "token-card" },
+    });
+    /** @type {__VLS_StyleScopedClasses['token-card']} */ ;
+    __VLS_asFunctionalElement1(__VLS_intrinsics.div, __VLS_intrinsics.div)({
+        ...{ class: "token-card__header" },
+    });
+    /** @type {__VLS_StyleScopedClasses['token-card__header']} */ ;
+    __VLS_asFunctionalElement1(__VLS_intrinsics.span, __VLS_intrinsics.span)({
+        ...{ class: "detail-item__label" },
+    });
+    /** @type {__VLS_StyleScopedClasses['detail-item__label']} */ ;
+    let __VLS_286;
+    /** @ts-ignore @type {typeof __VLS_components.elButton | typeof __VLS_components.ElButton | typeof __VLS_components.elButton | typeof __VLS_components.ElButton} */
+    elButton;
+    // @ts-ignore
+    const __VLS_287 = __VLS_asFunctionalComponent1(__VLS_286, new __VLS_286({
+        ...{ 'onClick': {} },
+        link: true,
+        type: "primary",
+        disabled: (!__VLS_ctx.selectedTokens.bind_card_url),
+    }));
+    const __VLS_288 = __VLS_287({
+        ...{ 'onClick': {} },
+        link: true,
+        type: "primary",
+        disabled: (!__VLS_ctx.selectedTokens.bind_card_url),
+    }, ...__VLS_functionalComponentArgsRest(__VLS_287));
+    let __VLS_291;
+    const __VLS_292 = ({ click: {} },
+        { onClick: (...[$event]) => {
+                if (!(__VLS_ctx.selectedAccount))
+                    return;
+                __VLS_ctx.copyValue(__VLS_ctx.selectedTokens.bind_card_url, '绑卡链接');
+                // @ts-ignore
+                [selectedTokens, selectedTokens, selectedTokens, copyValue,];
+            } });
+    const { default: __VLS_293 } = __VLS_289.slots;
+    // @ts-ignore
+    [];
+    var __VLS_289;
+    var __VLS_290;
+    __VLS_asFunctionalElement1(__VLS_intrinsics.code, __VLS_intrinsics.code)({});
+    (__VLS_ctx.selectedTokens.bind_card_url_summary || '-');
 }
 // @ts-ignore
-[selectedTokens, selectedTokens, selectedTokens,];
+[selectedTokens,];
 var __VLS_223;
 // @ts-ignore
 [];

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -50,6 +50,39 @@
             </el-button>
           </div>
         </el-form>
+
+        <el-divider content-position="left">最近成功账号</el-divider>
+        <div v-if="recentResults.length === 0" class="result-empty">
+          注册成功后会在这里显示绑卡链接，支持直接复制。
+        </div>
+        <div v-else class="result-list">
+          <article v-for="item in recentResults" :key="item.task_uuid" class="result-card">
+            <div class="result-card__header">
+              <div>
+                <strong>{{ item.email }}</strong>
+                <p class="result-card__meta">
+                  {{ item.source === 'login' ? '已存在账号登录' : '新注册账号' }}
+                </p>
+              </div>
+              <el-button
+                link
+                type="primary"
+                :disabled="!item.bind_card_url"
+                @click="copyValue(item.bind_card_url, '绑卡链接')"
+              >
+                复制链接
+              </el-button>
+            </div>
+            <div class="result-row">
+              <span class="result-row__label">绑卡链接</span>
+              <code>{{ item.bind_card_url_summary || '-' }}</code>
+            </div>
+            <div class="result-row result-row--meta">
+              <span>账号 ID {{ item.account_id || '-' }}</span>
+              <span>工作区 {{ item.workspace_id || '-' }}</span>
+            </div>
+          </article>
+        </div>
       </el-card>
 
       <el-card class="page-card log-card" shadow="never">
@@ -107,11 +140,22 @@ type BatchResponse = {
 }
 
 type TaskEvent = {
-  type: 'status' | 'log'
+  type: 'status' | 'log' | 'result'
   batch_id?: string
+  task_uuid?: string
   status?: string
   message?: string
   extra?: Record<string, unknown>
+}
+
+type RecentRegistrationResult = {
+  task_uuid: string
+  email: string
+  account_id: string
+  workspace_id: string
+  source: string
+  bind_card_url: string
+  bind_card_url_summary: string
 }
 
 const loading = ref(false)
@@ -119,6 +163,7 @@ const starting = ref(false)
 const socket = ref<WebSocket | null>(null)
 const websocketState = ref('未连接')
 const logs = ref<string[]>([])
+const recentResults = ref<RecentRegistrationResult[]>([])
 const activeBatchID = ref('')
 const registrationStats = reactive<RegistrationStats>({
   by_status: {},
@@ -169,6 +214,7 @@ async function startRegistration() {
   try {
     resetCurrent()
     logs.value = []
+    recentResults.value = []
 
     const response = await fetch('/api/registration/batch', {
       method: 'POST',
@@ -250,11 +296,40 @@ function applyEvent(payload: TaskEvent) {
 
   if (payload.type === 'log' && payload.message) {
     appendLog(payload.message)
+    return
+  }
+
+  if (payload.type === 'result') {
+    const result = normalizeRecentResult(payload)
+    if (!result) {
+      return
+    }
+
+    recentResults.value = [result, ...recentResults.value.filter((item) => item.task_uuid !== result.task_uuid)].slice(0, 8)
   }
 }
 
 function appendLog(message: string) {
   logs.value = [...logs.value, message].slice(-400)
+}
+
+function normalizeRecentResult(payload: TaskEvent): RecentRegistrationResult | null {
+  const extra = payload.extra ?? {}
+  const taskUUID = asString(extra.task_uuid) || payload.task_uuid || `${Date.now()}`
+  const email = asString(extra.email)
+  if (!email) {
+    return null
+  }
+
+  return {
+    task_uuid: taskUUID,
+    email,
+    account_id: asString(extra.account_id),
+    workspace_id: asString(extra.workspace_id),
+    source: asString(extra.source) || 'register',
+    bind_card_url: asString(extra.bind_card_url),
+    bind_card_url_summary: asString(extra.bind_card_url_summary),
+  }
 }
 
 function cancelRegistration() {
@@ -303,6 +378,42 @@ function isTerminalStatus(status: string) {
 
 function asNumber(value: unknown, fallback: number) {
   return typeof value === 'number' ? value : fallback
+}
+
+function asString(value: unknown) {
+  return typeof value === 'string' ? value : ''
+}
+
+async function copyValue(value: string, label: string) {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    ElMessage.warning(`${label} 不可复制`)
+    return
+  }
+
+  try {
+    await writeClipboard(trimmed)
+    ElMessage.success(`${label} 已复制`)
+  } catch {
+    ElMessage.error(`${label} 复制失败`)
+  }
+}
+
+async function writeClipboard(value: string) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(value)
+    return
+  }
+
+  const textarea = document.createElement('textarea')
+  textarea.value = value
+  textarea.setAttribute('readonly', 'true')
+  textarea.style.position = 'fixed'
+  textarea.style.opacity = '0'
+  document.body.appendChild(textarea)
+  textarea.select()
+  document.execCommand('copy')
+  document.body.removeChild(textarea)
 }
 
 const canCancel = computed(() => current.status === 'running' || current.status === 'cancelling')
@@ -385,6 +496,65 @@ onBeforeUnmount(() => {
 .launch-form {
   display: grid;
   gap: 18px;
+}
+
+.result-empty {
+  padding: 18px 16px;
+  border-radius: 16px;
+  background: #f8fafc;
+  color: #64748b;
+  font-size: 13px;
+}
+
+.result-list {
+  display: grid;
+  gap: 12px;
+}
+
+.result-card {
+  display: grid;
+  gap: 10px;
+  padding: 16px 18px;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.96) 0%, rgba(241, 245, 249, 0.96) 100%);
+}
+
+.result-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.result-card__meta {
+  margin: 6px 0 0;
+  color: #64748b;
+  font-size: 12px;
+}
+
+.result-row {
+  display: grid;
+  gap: 6px;
+}
+
+.result-row__label {
+  color: #52606d;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.result-row code {
+  font-size: 12px;
+  word-break: break-all;
+  white-space: pre-wrap;
+}
+
+.result-row--meta {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  color: #64748b;
+  font-size: 12px;
 }
 
 .launch-card :deep(.el-card__header),
@@ -497,7 +667,8 @@ onBeforeUnmount(() => {
   .hero,
   .section-header,
   .status-bar,
-  .form-actions {
+  .form-actions,
+  .result-card__header {
     flex-direction: column;
     align-items: flex-start;
   }
@@ -508,6 +679,10 @@ onBeforeUnmount(() => {
 
   .hero__title {
     font-size: 28px;
+  }
+
+  .result-row--meta {
+    grid-template-columns: 1fr;
   }
 }
 </style>

--- a/frontend/src/views/DashboardView.vue.js
+++ b/frontend/src/views/DashboardView.vue.js
@@ -5,6 +5,7 @@ const starting = ref(false);
 const socket = ref(null);
 const websocketState = ref('未连接');
 const logs = ref([]);
+const recentResults = ref([]);
 const activeBatchID = ref('');
 const registrationStats = reactive({
     by_status: {},
@@ -53,6 +54,7 @@ async function startRegistration() {
     try {
         resetCurrent();
         logs.value = [];
+        recentResults.value = [];
         const response = await fetch('/api/registration/batch', {
             method: 'POST',
             headers: {
@@ -124,10 +126,35 @@ function applyEvent(payload) {
     }
     if (payload.type === 'log' && payload.message) {
         appendLog(payload.message);
+        return;
+    }
+    if (payload.type === 'result') {
+        const result = normalizeRecentResult(payload);
+        if (!result) {
+            return;
+        }
+        recentResults.value = [result, ...recentResults.value.filter((item) => item.task_uuid !== result.task_uuid)].slice(0, 8);
     }
 }
 function appendLog(message) {
     logs.value = [...logs.value, message].slice(-400);
+}
+function normalizeRecentResult(payload) {
+    const extra = payload.extra ?? {};
+    const taskUUID = asString(extra.task_uuid) || payload.task_uuid || `${Date.now()}`;
+    const email = asString(extra.email);
+    if (!email) {
+        return null;
+    }
+    return {
+        task_uuid: taskUUID,
+        email,
+        account_id: asString(extra.account_id),
+        workspace_id: asString(extra.workspace_id),
+        source: asString(extra.source) || 'register',
+        bind_card_url: asString(extra.bind_card_url),
+        bind_card_url_summary: asString(extra.bind_card_url_summary),
+    };
 }
 function cancelRegistration() {
     if (!socket.value) {
@@ -171,6 +198,38 @@ function isTerminalStatus(status) {
 function asNumber(value, fallback) {
     return typeof value === 'number' ? value : fallback;
 }
+function asString(value) {
+    return typeof value === 'string' ? value : '';
+}
+async function copyValue(value, label) {
+    const trimmed = value.trim();
+    if (!trimmed) {
+        ElMessage.warning(`${label} 不可复制`);
+        return;
+    }
+    try {
+        await writeClipboard(trimmed);
+        ElMessage.success(`${label} 已复制`);
+    }
+    catch {
+        ElMessage.error(`${label} 复制失败`);
+    }
+}
+async function writeClipboard(value) {
+    if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(value);
+        return;
+    }
+    const textarea = document.createElement('textarea');
+    textarea.value = value;
+    textarea.setAttribute('readonly', 'true');
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+}
 const canCancel = computed(() => current.status === 'running' || current.status === 'cancelling');
 const websocketTagType = computed(() => {
     switch (websocketState.value) {
@@ -197,6 +256,7 @@ const __VLS_ctx = {
 let __VLS_components;
 let __VLS_intrinsics;
 let __VLS_directives;
+/** @type {__VLS_StyleScopedClasses['result-row']} */ ;
 /** @type {__VLS_StyleScopedClasses['el-card__header']} */ ;
 /** @type {__VLS_StyleScopedClasses['launch-card']} */ ;
 /** @type {__VLS_StyleScopedClasses['log-card']} */ ;
@@ -214,8 +274,10 @@ let __VLS_directives;
 /** @type {__VLS_StyleScopedClasses['section-header']} */ ;
 /** @type {__VLS_StyleScopedClasses['status-bar']} */ ;
 /** @type {__VLS_StyleScopedClasses['form-actions']} */ ;
+/** @type {__VLS_StyleScopedClasses['result-card__header']} */ ;
 /** @type {__VLS_StyleScopedClasses['hero']} */ ;
 /** @type {__VLS_StyleScopedClasses['hero__title']} */ ;
+/** @type {__VLS_StyleScopedClasses['result-row--meta']} */ ;
 __VLS_asFunctionalElement1(__VLS_intrinsics.div, __VLS_intrinsics.div)({
     ...{ class: "dashboard" },
 });
@@ -515,26 +577,122 @@ var __VLS_85;
 [];
 var __VLS_24;
 var __VLS_25;
+let __VLS_89;
+/** @ts-ignore @type {typeof __VLS_components.elDivider | typeof __VLS_components.ElDivider | typeof __VLS_components.elDivider | typeof __VLS_components.ElDivider} */
+elDivider;
+// @ts-ignore
+const __VLS_90 = __VLS_asFunctionalComponent1(__VLS_89, new __VLS_89({
+    contentPosition: "left",
+}));
+const __VLS_91 = __VLS_90({
+    contentPosition: "left",
+}, ...__VLS_functionalComponentArgsRest(__VLS_90));
+const { default: __VLS_94 } = __VLS_92.slots;
+// @ts-ignore
+[];
+var __VLS_92;
+if (__VLS_ctx.recentResults.length === 0) {
+    __VLS_asFunctionalElement1(__VLS_intrinsics.div, __VLS_intrinsics.div)({
+        ...{ class: "result-empty" },
+    });
+    /** @type {__VLS_StyleScopedClasses['result-empty']} */ ;
+}
+else {
+    __VLS_asFunctionalElement1(__VLS_intrinsics.div, __VLS_intrinsics.div)({
+        ...{ class: "result-list" },
+    });
+    /** @type {__VLS_StyleScopedClasses['result-list']} */ ;
+    for (const [item] of __VLS_vFor((__VLS_ctx.recentResults))) {
+        __VLS_asFunctionalElement1(__VLS_intrinsics.article, __VLS_intrinsics.article)({
+            key: (item.task_uuid),
+            ...{ class: "result-card" },
+        });
+        /** @type {__VLS_StyleScopedClasses['result-card']} */ ;
+        __VLS_asFunctionalElement1(__VLS_intrinsics.div, __VLS_intrinsics.div)({
+            ...{ class: "result-card__header" },
+        });
+        /** @type {__VLS_StyleScopedClasses['result-card__header']} */ ;
+        __VLS_asFunctionalElement1(__VLS_intrinsics.div, __VLS_intrinsics.div)({});
+        __VLS_asFunctionalElement1(__VLS_intrinsics.strong, __VLS_intrinsics.strong)({});
+        (item.email);
+        __VLS_asFunctionalElement1(__VLS_intrinsics.p, __VLS_intrinsics.p)({
+            ...{ class: "result-card__meta" },
+        });
+        /** @type {__VLS_StyleScopedClasses['result-card__meta']} */ ;
+        (item.source === 'login' ? '已存在账号登录' : '新注册账号');
+        let __VLS_95;
+        /** @ts-ignore @type {typeof __VLS_components.elButton | typeof __VLS_components.ElButton | typeof __VLS_components.elButton | typeof __VLS_components.ElButton} */
+        elButton;
+        // @ts-ignore
+        const __VLS_96 = __VLS_asFunctionalComponent1(__VLS_95, new __VLS_95({
+            ...{ 'onClick': {} },
+            link: true,
+            type: "primary",
+            disabled: (!item.bind_card_url),
+        }));
+        const __VLS_97 = __VLS_96({
+            ...{ 'onClick': {} },
+            link: true,
+            type: "primary",
+            disabled: (!item.bind_card_url),
+        }, ...__VLS_functionalComponentArgsRest(__VLS_96));
+        let __VLS_100;
+        const __VLS_101 = ({ click: {} },
+            { onClick: (...[$event]) => {
+                    if (!!(__VLS_ctx.recentResults.length === 0))
+                        return;
+                    __VLS_ctx.copyValue(item.bind_card_url, '绑卡链接');
+                    // @ts-ignore
+                    [recentResults, recentResults, copyValue,];
+                } });
+        const { default: __VLS_102 } = __VLS_98.slots;
+        // @ts-ignore
+        [];
+        var __VLS_98;
+        var __VLS_99;
+        __VLS_asFunctionalElement1(__VLS_intrinsics.div, __VLS_intrinsics.div)({
+            ...{ class: "result-row" },
+        });
+        /** @type {__VLS_StyleScopedClasses['result-row']} */ ;
+        __VLS_asFunctionalElement1(__VLS_intrinsics.span, __VLS_intrinsics.span)({
+            ...{ class: "result-row__label" },
+        });
+        /** @type {__VLS_StyleScopedClasses['result-row__label']} */ ;
+        __VLS_asFunctionalElement1(__VLS_intrinsics.code, __VLS_intrinsics.code)({});
+        (item.bind_card_url_summary || '-');
+        __VLS_asFunctionalElement1(__VLS_intrinsics.div, __VLS_intrinsics.div)({
+            ...{ class: "result-row result-row--meta" },
+        });
+        /** @type {__VLS_StyleScopedClasses['result-row']} */ ;
+        /** @type {__VLS_StyleScopedClasses['result-row--meta']} */ ;
+        __VLS_asFunctionalElement1(__VLS_intrinsics.span, __VLS_intrinsics.span)({});
+        (item.account_id || '-');
+        __VLS_asFunctionalElement1(__VLS_intrinsics.span, __VLS_intrinsics.span)({});
+        (item.workspace_id || '-');
+        // @ts-ignore
+        [];
+    }
+}
 // @ts-ignore
 [];
 var __VLS_11;
-let __VLS_89;
+let __VLS_103;
 /** @ts-ignore @type {typeof __VLS_components.elCard | typeof __VLS_components.ElCard | typeof __VLS_components.elCard | typeof __VLS_components.ElCard} */
 elCard;
 // @ts-ignore
-const __VLS_90 = __VLS_asFunctionalComponent1(__VLS_89, new __VLS_89({
+const __VLS_104 = __VLS_asFunctionalComponent1(__VLS_103, new __VLS_103({
     ...{ class: "page-card log-card" },
     shadow: "never",
 }));
-const __VLS_91 = __VLS_90({
+const __VLS_105 = __VLS_104({
     ...{ class: "page-card log-card" },
     shadow: "never",
-}, ...__VLS_functionalComponentArgsRest(__VLS_90));
+}, ...__VLS_functionalComponentArgsRest(__VLS_104));
 /** @type {__VLS_StyleScopedClasses['page-card']} */ ;
 /** @type {__VLS_StyleScopedClasses['log-card']} */ ;
-const { default: __VLS_94 } = __VLS_92.slots;
+const { default: __VLS_108 } = __VLS_106.slots;
 {
-    const { header: __VLS_95 } = __VLS_92.slots;
+    const { header: __VLS_109 } = __VLS_106.slots;
     __VLS_asFunctionalElement1(__VLS_intrinsics.div, __VLS_intrinsics.div)({
         ...{ class: "section-header" },
     });
@@ -547,36 +705,36 @@ const { default: __VLS_94 } = __VLS_92.slots;
         ...{ class: "status-bar" },
     });
     /** @type {__VLS_StyleScopedClasses['status-bar']} */ ;
-    let __VLS_96;
+    let __VLS_110;
     /** @ts-ignore @type {typeof __VLS_components.elTag | typeof __VLS_components.ElTag | typeof __VLS_components.elTag | typeof __VLS_components.ElTag} */
     elTag;
     // @ts-ignore
-    const __VLS_97 = __VLS_asFunctionalComponent1(__VLS_96, new __VLS_96({
+    const __VLS_111 = __VLS_asFunctionalComponent1(__VLS_110, new __VLS_110({
         type: (__VLS_ctx.statusTagType(__VLS_ctx.current.status)),
     }));
-    const __VLS_98 = __VLS_97({
+    const __VLS_112 = __VLS_111({
         type: (__VLS_ctx.statusTagType(__VLS_ctx.current.status)),
-    }, ...__VLS_functionalComponentArgsRest(__VLS_97));
-    const { default: __VLS_101 } = __VLS_99.slots;
+    }, ...__VLS_functionalComponentArgsRest(__VLS_111));
+    const { default: __VLS_115 } = __VLS_113.slots;
     (__VLS_ctx.current.status || '-');
     // @ts-ignore
     [statusTagType, current, current,];
-    var __VLS_99;
-    let __VLS_102;
+    var __VLS_113;
+    let __VLS_116;
     /** @ts-ignore @type {typeof __VLS_components.elTag | typeof __VLS_components.ElTag | typeof __VLS_components.elTag | typeof __VLS_components.ElTag} */
     elTag;
     // @ts-ignore
-    const __VLS_103 = __VLS_asFunctionalComponent1(__VLS_102, new __VLS_102({
+    const __VLS_117 = __VLS_asFunctionalComponent1(__VLS_116, new __VLS_116({
         type: (__VLS_ctx.websocketTagType),
     }));
-    const __VLS_104 = __VLS_103({
+    const __VLS_118 = __VLS_117({
         type: (__VLS_ctx.websocketTagType),
-    }, ...__VLS_functionalComponentArgsRest(__VLS_103));
-    const { default: __VLS_107 } = __VLS_105.slots;
+    }, ...__VLS_functionalComponentArgsRest(__VLS_117));
+    const { default: __VLS_121 } = __VLS_119.slots;
     (__VLS_ctx.websocketState);
     // @ts-ignore
     [websocketTagType, websocketState,];
-    var __VLS_105;
+    var __VLS_119;
     // @ts-ignore
     [];
 }
@@ -650,7 +808,7 @@ else {
 }
 // @ts-ignore
 [];
-var __VLS_92;
+var __VLS_106;
 // @ts-ignore
 [];
 const __VLS_export = (await import('vue')).defineComponent({});

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -411,6 +411,24 @@ func (m *TaskManager) runTask(ctx context.Context, batchID, taskUUID string, req
 		}
 	}
 
+	resultExtra := buildRegistrationResultEvent(taskUUID, accountID, result)
+	m.publishTaskEvent(taskUUID, TaskEvent{
+		Type:      "result",
+		TaskUUID:  taskUUID,
+		BatchID:   batchID,
+		Timestamp: time.Now().Format(time.RFC3339),
+		Extra:     resultExtra,
+	})
+	if strings.TrimSpace(batchID) != "" {
+		m.publishBatchEvent(batchID, TaskEvent{
+			Type:      "result",
+			TaskUUID:  taskUUID,
+			BatchID:   batchID,
+			Timestamp: time.Now().Format(time.RFC3339),
+			Extra:     resultExtra,
+		})
+	}
+
 	_, _ = m.db.UpdateRegistrationTask(context.Background(), taskUUID, map[string]any{
 		"status":       "completed",
 		"completed_at": time.Now().Format(time.RFC3339),
@@ -515,6 +533,38 @@ func randInt(n int) int {
 		return 0
 	}
 	return int(time.Now().UnixNano() % int64(n))
+}
+
+func buildRegistrationResultEvent(taskUUID string, accountDBID int, result RegistrationResult) map[string]any {
+	extra := map[string]any{
+		"task_uuid":    taskUUID,
+		"email":        result.Email,
+		"account_id":   result.AccountID,
+		"workspace_id": result.WorkspaceID,
+		"source":       result.Source,
+	}
+	if accountDBID > 0 {
+		extra["account_db_id"] = accountDBID
+	}
+	if strings.TrimSpace(result.BindCardURL) != "" {
+		extra["bind_card_url"] = result.BindCardURL
+		extra["bind_card_url_summary"] = summarizeValue(result.BindCardURL, 88)
+	}
+	return extra
+}
+
+func summarizeValue(value string, keep int) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	if keep < 16 {
+		keep = 16
+	}
+	if len(trimmed) <= keep {
+		return trimmed
+	}
+	return trimmed[:keep] + "..."
 }
 
 func maskProxyForLog(proxyURL string) string {

--- a/internal/runtime/payments.go
+++ b/internal/runtime/payments.go
@@ -1,0 +1,115 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	http "github.com/bogdanfinn/fhttp"
+)
+
+const (
+	bindCardCheckoutEndpoint = "https://chatgpt.com/backend-api/payments/checkout"
+	bindCardCheckoutBaseURL  = "https://chatgpt.com/checkout/openai_llc/"
+)
+
+func GenerateBindCardLink(ctx context.Context, accessToken, proxyURL string) (string, error) {
+	trimmedToken := strings.TrimSpace(accessToken)
+	if trimmedToken == "" {
+		return "", fmt.Errorf("账号没有 access_token")
+	}
+
+	client, err := newTokenClient(proxyURL)
+	if err != nil {
+		return "", err
+	}
+
+	payload := map[string]any{
+		"plan_name": "chatgptteamplan",
+		"team_plan_data": map[string]any{
+			"workspace_name": "MyTeam",
+			"price_interval": "month",
+			"seat_quantity":  5,
+		},
+		"promo_campaign": map[string]any{
+			"promo_campaign_id":          "team-1-month-free",
+			"is_coupon_from_query_param": true,
+		},
+		"checkout_ui_mode": "custom",
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, bindCardCheckoutEndpoint, strings.NewReader(string(body)))
+	req.Header = browserHeaders(http.Header{
+		"accept":             {"application/json, text/plain, */*"},
+		"accept-language":    {"en-US,en;q=0.9"},
+		"authorization":      {"Bearer " + trimmedToken},
+		"content-type":       {"application/json"},
+		"origin":             {"https://chatgpt.com"},
+		"referer":            {"https://chatgpt.com/"},
+		"sec-ch-ua":          {secCHUA()},
+		"sec-ch-ua-mobile":   {"?0"},
+		"sec-ch-ua-platform": {`"Windows"`},
+		"sec-fetch-dest":     {"empty"},
+		"sec-fetch-mode":     {"cors"},
+		"sec-fetch-site":     {"same-origin"},
+		"user-agent":         {userAgent()},
+	}, "accept", "accept-language", "authorization", "content-type", "origin", "referer", "sec-ch-ua", "sec-ch-ua-mobile", "sec-ch-ua-platform", "sec-fetch-dest", "sec-fetch-mode", "sec-fetch-site", "user-agent")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	var data map[string]any
+	_ = json.Unmarshal(respBody, &data)
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf(resolveCheckoutError(data, resp.StatusCode))
+	}
+
+	checkoutURL := resolveCheckoutURL(data)
+	if checkoutURL == "" {
+		return "", fmt.Errorf("未返回绑卡链接")
+	}
+	return checkoutURL, nil
+}
+
+func resolveCheckoutURL(data map[string]any) string {
+	if value := strings.TrimSpace(asString(data["checkout_session_id"])); value != "" {
+		return buildCheckoutURL(value)
+	}
+
+	urlValue := strings.TrimSpace(asString(data["url"]))
+	if urlValue == "" {
+		return ""
+	}
+
+	if match := checkoutSessionPattern.FindStringSubmatch(urlValue); len(match) >= 2 {
+		return buildCheckoutURL(match[1])
+	}
+
+	return urlValue
+}
+
+func buildCheckoutURL(checkoutSessionID string) string {
+	return bindCardCheckoutBaseURL + strings.TrimSpace(checkoutSessionID)
+}
+
+func resolveCheckoutError(data map[string]any, status int) string {
+	for _, key := range []string{"detail", "message", "error"} {
+		if value := strings.TrimSpace(asString(data[key])); value != "" {
+			return value
+		}
+	}
+	return fmt.Sprintf("HTTP %d", status)
+}

--- a/internal/runtime/registration.go
+++ b/internal/runtime/registration.go
@@ -29,6 +29,8 @@ const (
 	otpPattern               = `\b(\d{6})\b`
 )
 
+var checkoutSessionPattern = regexp.MustCompile(`/checkout/openai_llc/([A-Za-z0-9_-]+)`)
+
 type engineSettings struct {
 	OpenAIClientID        string
 	OpenAIAuthURL         string
@@ -49,6 +51,7 @@ type RegistrationResult struct {
 	RefreshToken string         `json:"refresh_token,omitempty"`
 	IDToken      string         `json:"id_token,omitempty"`
 	SessionToken string         `json:"session_token,omitempty"`
+	BindCardURL  string         `json:"bind_card_url,omitempty"`
 	ErrorMessage string         `json:"error_message,omitempty"`
 	Metadata     map[string]any `json:"metadata,omitempty"`
 	Source       string         `json:"source"`
@@ -234,11 +237,24 @@ func (e *registrationEngine) run(ctx context.Context) RegistrationResult {
 	result.IDToken = tokenInfo.IDToken
 	result.Password = e.password
 	result.SessionToken = e.getCookieValue("https://chatgpt.com", "__Secure-next-auth.session-token")
+
+	e.logf("生成绑卡链接")
+	bindCardURL, err := GenerateBindCardLink(ctx, tokenInfo.AccessToken, e.proxyURL)
+	if err != nil {
+		e.logf("绑卡链接生成失败: " + err.Error())
+	} else {
+		result.BindCardURL = bindCardURL
+		e.logf("绑卡链接已生成")
+	}
+
 	result.Metadata = map[string]any{
 		"email_service":       e.service.Type(),
 		"proxy_used":          e.proxyURL,
 		"registered_at":       time.Now().Format(time.RFC3339),
 		"is_existing_account": e.isExisting,
+	}
+	if result.BindCardURL != "" {
+		result.Metadata["bind_card_url"] = result.BindCardURL
 	}
 	e.logf("注册流程完成")
 

--- a/internal/server/accounts_api.go
+++ b/internal/server/accounts_api.go
@@ -76,13 +76,31 @@ func (a *apiServer) handleAccountTokens(w http.ResponseWriter, req *http.Request
 		return
 	}
 
+	bindCardURL := accountExtraString(account.ExtraData, "bind_card_url")
+	if bindCardURL == "" && account.AccessToken != nil {
+		generatedURL, err := runtime.GenerateBindCardLink(req.Context(), *account.AccessToken, pointerValue(account.ProxyUsed))
+		if err == nil && generatedURL != "" {
+			bindCardURL = generatedURL
+			mergedExtra := cloneExtraData(account.ExtraData)
+			mergedExtra["bind_card_url"] = generatedURL
+			if updateErr := a.store.UpdateAccount(req.Context(), accountID, map[string]any{"extra_data": mergedExtra}); updateErr == nil {
+				account.ExtraData = mergedExtra
+			}
+		}
+	}
+
 	writeJSON(w, http.StatusOK, map[string]any{
-		"id":            account.ID,
-		"email":         account.Email,
-		"access_token":  truncateToken(account.AccessToken),
-		"refresh_token": truncateToken(account.RefreshToken),
-		"id_token":      truncateToken(account.IDToken),
-		"has_tokens":    account.AccessToken != nil && account.RefreshToken != nil,
+		"id":                    account.ID,
+		"email":                 account.Email,
+		"access_token":          pointerValue(account.AccessToken),
+		"access_token_summary":  truncateValue(pointerValue(account.AccessToken), 50),
+		"refresh_token":         pointerValue(account.RefreshToken),
+		"refresh_token_summary": truncateValue(pointerValue(account.RefreshToken), 50),
+		"id_token":              pointerValue(account.IDToken),
+		"id_token_summary":      truncateValue(pointerValue(account.IDToken), 50),
+		"bind_card_url":         bindCardURL,
+		"bind_card_url_summary": truncateValue(bindCardURL, 72),
+		"has_tokens":            account.AccessToken != nil && account.RefreshToken != nil,
 	})
 }
 
@@ -276,11 +294,49 @@ func (a *apiServer) handleBatchCPAUpload(w http.ResponseWriter, req *http.Reques
 }
 
 func truncateToken(value *string) any {
-	if value == nil || strings.TrimSpace(*value) == "" {
+	if value == nil {
 		return nil
 	}
-	if len(*value) <= 50 {
-		return *value
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil
 	}
-	return (*value)[:50] + "..."
+	return truncateValue(trimmed, 50)
+}
+
+func truncateValue(value string, keep int) any {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	if keep < 16 {
+		keep = 16
+	}
+	if len(trimmed) <= keep {
+		return trimmed
+	}
+	return trimmed[:keep] + "..."
+}
+
+func accountExtraString(extra map[string]any, key string) string {
+	if len(extra) == 0 {
+		return ""
+	}
+	value, _ := extra[key].(string)
+	return strings.TrimSpace(value)
+}
+
+func cloneExtraData(extra map[string]any) map[string]any {
+	result := map[string]any{}
+	for key, value := range extra {
+		result[key] = value
+	}
+	return result
+}
+
+func pointerValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
 }

--- a/internal/store/accounts.go
+++ b/internal/store/accounts.go
@@ -36,16 +36,18 @@ type Account struct {
 }
 
 type AccountTokens struct {
-	ID           int     `json:"id"`
-	Email        string  `json:"email"`
-	ClientID     *string `json:"client_id,omitempty"`
-	AccessToken  *string `json:"access_token,omitempty"`
-	RefreshToken *string `json:"refresh_token,omitempty"`
-	IDToken      *string `json:"id_token,omitempty"`
-	SessionToken *string `json:"session_token,omitempty"`
-	LastRefresh  string  `json:"last_refresh,omitempty"`
-	ExpiresAt    string  `json:"expires_at,omitempty"`
-	AccountID    *string `json:"account_id,omitempty"`
+	ID           int            `json:"id"`
+	Email        string         `json:"email"`
+	ClientID     *string        `json:"client_id,omitempty"`
+	AccessToken  *string        `json:"access_token,omitempty"`
+	RefreshToken *string        `json:"refresh_token,omitempty"`
+	IDToken      *string        `json:"id_token,omitempty"`
+	SessionToken *string        `json:"session_token,omitempty"`
+	LastRefresh  string         `json:"last_refresh,omitempty"`
+	ExpiresAt    string         `json:"expires_at,omitempty"`
+	AccountID    *string        `json:"account_id,omitempty"`
+	ProxyUsed    *string        `json:"proxy_used,omitempty"`
+	ExtraData    map[string]any `json:"extra_data,omitempty"`
 }
 
 type AccountCreate struct {
@@ -258,7 +260,9 @@ SELECT
 	session_token,
 	last_refresh,
 	expires_at,
-	account_id
+	account_id,
+	proxy_used,
+	extra_data
 FROM accounts
 WHERE id = ?`
 
@@ -560,6 +564,8 @@ func scanAccountTokens(row scanner) (AccountTokens, error) {
 		lastRefresh  sql.NullString
 		expiresAt    sql.NullString
 		accountID    sql.NullString
+		proxyUsed    sql.NullString
+		extraData    sql.NullString
 	)
 
 	err := row.Scan(
@@ -573,6 +579,8 @@ func scanAccountTokens(row scanner) (AccountTokens, error) {
 		&lastRefresh,
 		&expiresAt,
 		&accountID,
+		&proxyUsed,
+		&extraData,
 	)
 	if err != nil {
 		return AccountTokens{}, err
@@ -586,7 +594,20 @@ func scanAccountTokens(row scanner) (AccountTokens, error) {
 	account.LastRefresh = normalizeTimestamp(lastRefresh)
 	account.ExpiresAt = normalizeTimestamp(expiresAt)
 	account.AccountID = nullableString(accountID)
+	account.ProxyUsed = nullableString(proxyUsed)
+	account.ExtraData = parseExtraData(extraData)
 	return account, nil
+}
+
+func parseExtraData(value sql.NullString) map[string]any {
+	result := map[string]any{}
+	if !value.Valid || strings.TrimSpace(value.String) == "" {
+		return result
+	}
+	if err := json.Unmarshal([]byte(value.String), &result); err != nil {
+		return map[string]any{}
+	}
+	return result
 }
 
 func nullableString(value sql.NullString) *string {


### PR DESCRIPTION
## Summary
- generate Team checkout links after registration and persist them with account metadata
- expose full token and bind-card link values plus summaries in the account detail API
- show recent registration results and copy actions in the dashboard and account detail views

## Testing
- staged snapshot: `cd frontend && npm run build`
- staged snapshot: `go build ./...`